### PR TITLE
fix for Viewable impression event

### DIFF
--- a/js/src/tracking/viewable-impression.js
+++ b/js/src/tracking/viewable-impression.js
@@ -4,12 +4,18 @@ import TRACKING_EVENTS from '../tracking/tracking-events';
 const VIEWABLE_IMPRESSION = {};
 
 const _handleIntersect = function (entries) {
+  const visibiliyThreshold = 0.5;
   entries.forEach(entry => {
     if (entry.intersectionRatio > this.viewablePreviousRatio) {
       this.viewableObserver.unobserve(this.container);
       HELPERS.createApiEvent.call(this, 'adviewable');
       TRACKING_EVENTS.dispatch.call(this, 'viewable'); 
     }
+    else if (entry.intersectionRatio < visibiliyThreshold){
+      this.viewableObserver.unobserve(this.container);
+      HELPERS.createApiEvent.call(this, 'notviewable');
+      TRACKING_EVENTS.dispatch.call(this, 'notviewable'); 
+    }   
     this.viewablePreviousRatio = entry.intersectionRatio;
   });
 };

--- a/vast-client-js/src/parser/parser_utils.js
+++ b/vast-client-js/src/parser/parser_utils.js
@@ -228,6 +228,22 @@ function mergeWrapperAdData(unwrappedAd, wrapper) {
   );
   unwrappedAd.extensions = wrapper.extensions.concat(unwrappedAd.extensions);
 
+  // merge viewableImpressions from child and parent
+  if(wrapper.viewableImpression.notviewable)
+  unwrappedAd.viewableImpression.notviewable = wrapper.viewableImpression.notviewable.concat(
+    unwrappedAd.viewableImpression.notviewable
+  );
+
+  if(wrapper.viewableImpression.viewable)
+  unwrappedAd.viewableImpression.viewable = wrapper.viewableImpression.viewable.concat(
+    unwrappedAd.viewableImpression.viewable
+  );
+
+  if(wrapper.viewableImpression.viewundetermined)
+  unwrappedAd.viewableImpression.viewundetermined = wrapper.viewableImpression.viewundetermined.concat(
+    unwrappedAd.viewableImpression.viewundetermined
+  );
+
   // values from the child wrapper will be overridden
   unwrappedAd.followAdditionalWrappers = wrapper.followAdditionalWrappers;
   unwrappedAd.allowMultipleAds = wrapper.allowMultipleAds;


### PR DESCRIPTION
This fixes the issue: [https://github.com/radiantmediaplayer/rmp-vast/issues/33](url) where viewable impressions events (like: Viewable & NotViewable) not firing when the vast file contains a Wrapper tag.