### PR TITLE
Add fetchOptions as a param in order to be able to pass through custom headers to the vast client

### DIFF
--- a/src/js/helpers/utils.js
+++ b/src/js/helpers/utils.js
@@ -13,7 +13,7 @@ export default class Utils {
   }
 
   // attach fullscreen states
-  // this assumes we have a polyfill for fullscreenchange event 
+  // this assumes we have a polyfill for fullscreenchange event
   // see app/js/app.js
   // we need this to handle VAST fullscreen events
   #onFullscreenchange(event) {
@@ -173,7 +173,7 @@ export default class Utils {
       description: 'SIMID error: SPEC_NOT_FOLLOWED_ON_MESSAGES'
     }];
 
-    // Indicates that the error was encountered after the ad loaded, during ad play. 
+    // Indicates that the error was encountered after the ad loaded, during ad play.
     // Possible causes: ad assets could not be loaded, etc.
     const playErrorsList = [
       201, 204, 205,
@@ -184,7 +184,7 @@ export default class Utils {
       1002
     ];
 
-    // Indicates that the error was encountered when the ad was being loaded. 
+    // Indicates that the error was encountered when the ad was being loaded.
     // Possible causes: there was no response from the ad server, malformed ad response was returned ...
     // 300, 301, 302, 303, 304 Wrapper errors are managed in ast-client-js
     const loadErrorsList = [
@@ -220,6 +220,7 @@ export default class Utils {
       ajaxTimeout: 8000,
       creativeLoadTimeout: 8000,
       ajaxWithCredentials: false,
+      fetchOptions: {},
       maxNumRedirects: 4,
       labels: {
         skipMessage: 'Skip ad',
@@ -308,7 +309,7 @@ export default class Utils {
     if (targetPlayer) {
       const playPromise = targetPlayer.play();
       // most modern browsers support play as a Promise
-      // this lets us handle autoplay rejection 
+      // this lets us handle autoplay rejection
       // https://developers.google.com/web/updates/2016/03/play-returns-promise
       if (playPromise !== undefined) {
         const isLinear = this.#rmpVast.creative.isLinear;
@@ -347,7 +348,7 @@ export default class Utils {
     // if we have native fullscreen support we handle fullscreen events
     if (Environment.hasNativeFullscreenSupport) {
       this.#onFullscreenchangeFn = this.#onFullscreenchange.bind(this);
-      // for iOS 
+      // for iOS
       if (Environment.isIos[0]) {
         if (this.#rmpVast.currentContentPlayer) {
           this.#rmpVast.currentContentPlayer.addEventListener('webkitbeginfullscreen', this.#onFullscreenchangeFn);

--- a/src/js/helpers/utils.js
+++ b/src/js/helpers/utils.js
@@ -220,6 +220,7 @@ export default class Utils {
       ajaxTimeout: 8000,
       creativeLoadTimeout: 8000,
       ajaxWithCredentials: false,
+      fetchOptions: {},
       maxNumRedirects: 4,
       labels: {
         skipMessage: 'Skip ad',

--- a/src/js/helpers/utils.js
+++ b/src/js/helpers/utils.js
@@ -13,7 +13,7 @@ export default class Utils {
   }
 
   // attach fullscreen states
-  // this assumes we have a polyfill for fullscreenchange event
+  // this assumes we have a polyfill for fullscreenchange event 
   // see app/js/app.js
   // we need this to handle VAST fullscreen events
   #onFullscreenchange(event) {
@@ -173,7 +173,7 @@ export default class Utils {
       description: 'SIMID error: SPEC_NOT_FOLLOWED_ON_MESSAGES'
     }];
 
-    // Indicates that the error was encountered after the ad loaded, during ad play.
+    // Indicates that the error was encountered after the ad loaded, during ad play. 
     // Possible causes: ad assets could not be loaded, etc.
     const playErrorsList = [
       201, 204, 205,
@@ -184,7 +184,7 @@ export default class Utils {
       1002
     ];
 
-    // Indicates that the error was encountered when the ad was being loaded.
+    // Indicates that the error was encountered when the ad was being loaded. 
     // Possible causes: there was no response from the ad server, malformed ad response was returned ...
     // 300, 301, 302, 303, 304 Wrapper errors are managed in ast-client-js
     const loadErrorsList = [
@@ -220,7 +220,6 @@ export default class Utils {
       ajaxTimeout: 8000,
       creativeLoadTimeout: 8000,
       ajaxWithCredentials: false,
-      fetchOptions: {},
       maxNumRedirects: 4,
       labels: {
         skipMessage: 'Skip ad',
@@ -309,7 +308,7 @@ export default class Utils {
     if (targetPlayer) {
       const playPromise = targetPlayer.play();
       // most modern browsers support play as a Promise
-      // this lets us handle autoplay rejection
+      // this lets us handle autoplay rejection 
       // https://developers.google.com/web/updates/2016/03/play-returns-promise
       if (playPromise !== undefined) {
         const isLinear = this.#rmpVast.creative.isLinear;
@@ -348,7 +347,7 @@ export default class Utils {
     // if we have native fullscreen support we handle fullscreen events
     if (Environment.hasNativeFullscreenSupport) {
       this.#onFullscreenchangeFn = this.#onFullscreenchange.bind(this);
-      // for iOS
+      // for iOS 
       if (Environment.isIos[0]) {
         if (this.#rmpVast.currentContentPlayer) {
           this.#rmpVast.currentContentPlayer.addEventListener('webkitbeginfullscreen', this.#onFullscreenchangeFn);

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -33,13 +33,13 @@ export default class RmpVast {
    * @typedef {object} Labels
    * @property {string} [skipMessage]
    * @property {string} [closeAd]
-   * @property {string} [textForInteractionUIOnMobile] 
+   * @property {string} [textForInteractionUIOnMobile]
    * @typedef {object} RmpVastParams
    * @property {number} [ajaxTimeout] - timeout in ms for an AJAX request to load a VAST tag from the ad server.
    *  Default 8000.
-   * @property {number} [creativeLoadTimeout] - timeout in ms to load linear media creative from the server. 
+   * @property {number} [creativeLoadTimeout] - timeout in ms to load linear media creative from the server.
    *  Default 10000.
-   * @property {boolean} [ajaxWithCredentials] - AJAX request to load VAST tag from ad server should or should not be 
+   * @property {boolean} [ajaxWithCredentials] - AJAX request to load VAST tag from ad server should or should not be
    *  made with credentials. Default: false.
    * @property {number} [maxNumRedirects] - the number of VAST wrappers the player should follow before triggering an
    *  error. Default: 4. Capped at 30 to avoid infinite wrapper loops.
@@ -47,23 +47,23 @@ export default class RmpVast {
    * @property {boolean} [showControlsForAdPlayer] - Shows Ad player HTML5 default video controls. Default: false.
    * @property {boolean} [vastXmlInput] - Instead of a VAST URI, we provide directly to rmp-vast VAST XML. Default: false.
    * @property {boolean} [enableVpaid] - Enables VPAID support or not. Default: true.
-   * @property {VpaidSettings} [vpaidSettings] - Information required to display VPAID creatives - note that it is up 
+   * @property {VpaidSettings} [vpaidSettings] - Information required to display VPAID creatives - note that it is up
    *  to the parent application of rmp-vast to provide those informations
    * @property {boolean} [useHlsJS] - Enables hls.js usage to display creatives delivered in HLS format on all devices. Include hls.js library (./externals/hls/hls.min.js) in your page before usage. Default: true.
    * @property {boolean} [debugHlsJS] - Enables debug log when hls.js is used to stream creatives. Default: false.
    * @property {boolean} [debugRawConsoleLogs] - Enables raw debug console log for Flutter apps and legacy platforms. Default: false.
   * @property {boolean} [omidSupport] - Enables OMID (OM Web SDK) support in rmp-vast. Default: false.
-   * @property {string[]} [omidAllowedVendors] - List of allowed vendors for ad verification. Vendors not listed will 
+   * @property {string[]} [omidAllowedVendors] - List of allowed vendors for ad verification. Vendors not listed will
    *  be rejected. Default: [].
-   * @property {boolean} [omidAutoplay] - The content player will autoplay or not. The possibility of autoplay is not 
-   *  determined by rmp-vast, this information needs to be passed to rmp-vast (see this 
+   * @property {boolean} [omidAutoplay] - The content player will autoplay or not. The possibility of autoplay is not
+   *  determined by rmp-vast, this information needs to be passed to rmp-vast (see this
    *  script for example). Default: false (means a click to play is required).
    * @property {string} [partnerName] - partnerName for OMID. Default: 'rmp-vast'.
    * @property {string} [partnerVersion] - partnerVersion for OMID. Default: current rmp-vast version 'x.x.x'.
-   * @property {Labels} [labels] - Information required to properly display VPAID creatives - note that it is up to the 
+   * @property {Labels} [labels] - Information required to properly display VPAID creatives - note that it is up to the
    *  parent application of rmp-vast to provide those informations
-   * @property {object} [macros] - 
-   * @param {RmpVastParams} [params] - An object representing various parameters that can be passed to a rmp-vast 
+   * @property {object} [macros] -
+   * @param {RmpVastParams} [params] - An object representing various parameters that can be passed to a rmp-vast
    *  instance and that will affect the player inner-workings. Optional parameter.
    */
   constructor(idOrElement, params) {
@@ -96,7 +96,6 @@ export default class RmpVast {
     }
 
     Logger.print(this.debugRawConsoleLogs, `Filtered params follow`, this.params);
-
     Logger.print(this.debugRawConsoleLogs, `Creating new RmpVast instance`);
 
     this.rmpVastContentPlayer = new ContentPlayer(this);
@@ -105,7 +104,7 @@ export default class RmpVast {
     this.environmentData = Environment;
 
     Logger.printVideoEvents(this.debugRawConsoleLogs, this.currentContentPlayer, 'content');
-    // reset loadAds variables - this is reset at addestroyed 
+    // reset loadAds variables - this is reset at addestroyed
     // so that next loadAds is cleared
     this.resetVariablesForNewLoadAds();
     // handle fullscreen events
@@ -172,9 +171,9 @@ export default class RmpVast {
   }
 
 
-  /** 
+  /**
    * Dispatch an event to the custom event system
-   * @type {(eventName: string, data: object) => void} 
+   * @type {(eventName: string, data: object) => void}
    */
   dispatch(eventName, data) {
     const event = this.events[eventName];
@@ -189,7 +188,7 @@ export default class RmpVast {
     }
   }
 
-  /** 
+  /**
    * @private
    */
   #on(eventName, callback) {
@@ -204,9 +203,9 @@ export default class RmpVast {
     event.registerCallback(callback);
   }
 
-  /** 
+  /**
    * Listen to an event from the custom event system
-   * @type {(eventName: string, callback: function) => void} 
+   * @type {(eventName: string, callback: function) => void}
    */
   on(eventName, callback) {
     if (typeof eventName !== 'string' || eventName === '' || typeof callback !== 'function') {
@@ -218,7 +217,7 @@ export default class RmpVast {
     });
   }
 
-  /** 
+  /**
    * @private
    */
   #one(eventName, callback) {
@@ -229,9 +228,9 @@ export default class RmpVast {
     this.on(eventName, newCallback);
   }
 
-  /** 
+  /**
    * Listen once to an event from the custom event system
-   * @type {(eventName: string, callback: function) => void} 
+   * @type {(eventName: string, callback: function) => void}
    */
   one(eventName, callback) {
     if (typeof eventName !== 'string' || eventName === '' || typeof callback !== 'function') {
@@ -243,7 +242,7 @@ export default class RmpVast {
     });
   }
 
-  /** 
+  /**
    * @private
    */
   #off(eventName, callback) {
@@ -260,9 +259,9 @@ export default class RmpVast {
     }
   }
 
-  /** 
+  /**
    * Unregister an event from the custom event system
-   * @type {(eventName: string, callback: function) => void} 
+   * @type {(eventName: string, callback: function) => void}
    */
   off(eventName, callback) {
     if (typeof eventName !== 'string' || eventName === '' || typeof callback !== 'function') {
@@ -274,7 +273,7 @@ export default class RmpVast {
     });
   }
 
-  /** 
+  /**
    * @private
    */
   #addTrackingEvents(trackingEvents) {
@@ -289,7 +288,7 @@ export default class RmpVast {
     });
   }
 
-  /** 
+  /**
    * @private
    */
   #handleIntersect(entries) {
@@ -302,7 +301,7 @@ export default class RmpVast {
     });
   }
 
-  /** 
+  /**
    * @private
    */
   #attachViewableObserver() {
@@ -320,7 +319,7 @@ export default class RmpVast {
     }
   }
 
-  /** 
+  /**
    * @private
    */
   #initViewableImpression() {
@@ -357,7 +356,7 @@ export default class RmpVast {
     this.on('adstarted', this.attachViewableObserverFn);
   }
 
-  /** 
+  /**
    * @private
    */
   async #loopAds(ads) {
@@ -542,7 +541,7 @@ export default class RmpVast {
     }
   }
 
-  /** 
+  /**
    * @private
    */
   #handleParsedVast(response) {
@@ -557,7 +556,7 @@ export default class RmpVast {
         });
       });
     }
-    // VAST/Ad 
+    // VAST/Ad
     if (response.ads.length === 0) {
       this.rmpVastUtils.processVastErrors(303, true);
       return;
@@ -566,7 +565,7 @@ export default class RmpVast {
     }
   }
 
-  /** 
+  /**
    * @private
    */
   #getVastTag(vastData) {
@@ -586,6 +585,7 @@ export default class RmpVast {
       const options = {
         timeout: this.params.ajaxTimeout,
         withCredentials: this.params.ajaxWithCredentials,
+        fetchOptions: this.params.fetchOptions,
         wrapperLimit: this.params.maxNumRedirects,
         resolveAll: false,
         allowMultipleAds: true
@@ -625,12 +625,12 @@ export default class RmpVast {
     }
   }
 
-  /** 
+  /**
    * @param {string} vastData - the URI to the VAST resource to be loaded - or raw VAST XML if params.vastXmlInput is true
    * @param {object} [regulationsInfo] - data for regulations as
    * @param {string} [regulationsInfo.regulations] - coppa|gdpr for REGULATIONS macro
    * @param {string} [regulationsInfo.limitAdTracking] - 0|1 for LIMITADTRACKING macro
-   * @param {string} [regulationsInfo.gdprConsent] - Base64-encoded Cookie Value of IAB GDPR consent info for 
+   * @param {string} [regulationsInfo.gdprConsent] - Base64-encoded Cookie Value of IAB GDPR consent info for
    *  GDPRCONSENT macro
    * @param {boolean} [requireCategory] - for enforcement of VAST 4 Ad Categories
    * @return {void}
@@ -675,8 +675,8 @@ export default class RmpVast {
     this.#getVastTag(finalVastData);
   }
 
-  /** 
-   * @type {() => void} 
+  /**
+   * @type {() => void}
    */
   play() {
     if (this.__adOnStage && this.creative && this.creative.isLinear) {
@@ -690,8 +690,8 @@ export default class RmpVast {
     }
   }
 
-  /** 
-   * @type {() => void} 
+  /**
+   * @type {() => void}
    */
   pause() {
     if (this.__adOnStage && this.creative && this.creative.isLinear) {
@@ -705,8 +705,8 @@ export default class RmpVast {
     }
   }
 
-  /** 
-   * @type {() => void} 
+  /**
+   * @type {() => void}
    */
   stopAds() {
     if (this.__adOnStage) {
@@ -721,10 +721,10 @@ export default class RmpVast {
     }
   }
 
-  /** 
+  /**
    * The difference between stopAds and destroy is that after calling destroy you may not call loadAds again
-   * You will need to create a new RmpVast instance. 
-   * @type {() => void} 
+   * You will need to create a new RmpVast instance.
+   * @type {() => void}
    */
   destroy() {
     this.rmpVastUtils.destroyFullscreen();
@@ -734,8 +734,8 @@ export default class RmpVast {
     this.#initInstanceVariables();
   }
 
-  /** 
-   * @type {() => void} 
+  /**
+   * @type {() => void}
    */
   skipAd() {
     if (this.__adOnStage && this.adSkippableState) {
@@ -750,7 +750,7 @@ export default class RmpVast {
     }
   }
 
-  /** 
+  /**
  * @typedef {object} Environment
  * @property {number} devicePixelRatio
  * @property {number} maxTouchPoints
@@ -767,8 +767,8 @@ export default class RmpVast {
     return this.environmentData;
   }
 
-  /** 
-   * @type {() => boolean} 
+  /**
+   * @type {() => boolean}
    */
   get adPaused() {
     if (this.__adOnStage && this.creative && this.creative.isLinear) {
@@ -781,8 +781,8 @@ export default class RmpVast {
     return false;
   }
 
-  /** 
-   * @type {(level: number) => void} 
+  /**
+   * @type {(level: number) => void}
    */
   set volume(level) {
     if (!FW.isNumber(level)) {
@@ -807,8 +807,8 @@ export default class RmpVast {
     this.rmpVastContentPlayer.volume = validatedLevel;
   }
 
-  /** 
-   * @type {() => number} 
+  /**
+   * @type {() => number}
    */
   get volume() {
     if (this.__adOnStage && this.creative && this.creative.isLinear) {
@@ -821,8 +821,8 @@ export default class RmpVast {
     return this.rmpVastContentPlayer.volume;
   }
 
-  /** 
-   * @type {(muted: boolean) => void} 
+  /**
+   * @type {(muted: boolean) => void}
    */
   set muted(muted) {
     if (typeof muted !== 'boolean') {
@@ -842,8 +842,8 @@ export default class RmpVast {
     this.rmpVastContentPlayer.muted = muted;
   }
 
-  /** 
-   * @type {() => boolean} 
+  /**
+   * @type {() => boolean}
    */
   get muted() {
     if (this.__adOnStage && this.creative && this.creative.isLinear) {
@@ -859,15 +859,15 @@ export default class RmpVast {
     return this.rmpVastContentPlayer.muted;
   }
 
-  /** 
-   * @type {() => string} 
+  /**
+   * @type {() => string}
    */
   get adTagUrl() {
     return this.__adTagUrl;
   }
 
-  /** 
-   * @type {() => string} 
+  /**
+   * @type {() => string}
    */
   get adMediaUrl() {
     if (this.__adOnStage) {
@@ -882,8 +882,8 @@ export default class RmpVast {
     return '';
   }
 
-  /** 
-   * @type {() => boolean} 
+  /**
+   * @type {() => boolean}
    */
   get adLinear() {
     if (this.creative && this.creative.isLinear) {
@@ -892,7 +892,7 @@ export default class RmpVast {
     return false;
   }
 
-  /** 
+  /**
    * @typedef {object} AdSystem
    * @property {string} value
    * @property {string} version
@@ -914,7 +914,7 @@ export default class RmpVast {
     };
   }
 
-  /** 
+  /**
    * @typedef {object} universalAdId
    * @property {string} idRegistry
    * @property {string} value
@@ -929,8 +929,8 @@ export default class RmpVast {
     return [];
   }
 
-  /** 
-   * @type {() => string} 
+  /**
+   * @type {() => string}
    */
   get adContentType() {
     if (this.creative && this.creative.type) {
@@ -939,8 +939,8 @@ export default class RmpVast {
     return '';
   }
 
-  /** 
-   * @type {() => string} 
+  /**
+   * @type {() => string}
    */
   get adTitle() {
     if (this.ad && this.ad.title) {
@@ -949,8 +949,8 @@ export default class RmpVast {
     return '';
   }
 
-  /** 
-   * @type {() => string} 
+  /**
+   * @type {() => string}
    */
   get adDescription() {
     if (this.ad && this.ad.description) {
@@ -959,7 +959,7 @@ export default class RmpVast {
     return '';
   }
 
-  /** 
+  /**
    * @typedef {object} Advertiser
    * @property {string} id
    * @property {string} value
@@ -977,7 +977,7 @@ export default class RmpVast {
     };
   }
 
-  /** 
+  /**
    * @typedef {object} Pricing
    * @property {string} value
    * @property {string} model
@@ -997,8 +997,8 @@ export default class RmpVast {
     };
   }
 
-  /** 
-   * @type {() => string} 
+  /**
+   * @type {() => string}
    */
   get adSurvey() {
     if (this.ad && this.ad.survey) {
@@ -1010,8 +1010,8 @@ export default class RmpVast {
     };
   }
 
-  /** 
-   * @type {() => string} 
+  /**
+   * @type {() => string}
    */
   get adAdServingId() {
     if (this.ad && this.ad.adServingId) {
@@ -1020,36 +1020,36 @@ export default class RmpVast {
     return '';
   }
 
-  /** 
+  /**
    * @typedef {object} Category
    * @property {string} authority
    * @property {string} value
    * @return {Category[]}
    */
   get adCategories() {
-    // <Category authority=”iabtechlab.com”>232</Category> 
+    // <Category authority=”iabtechlab.com”>232</Category>
     if (this.ad && this.ad.categories && this.ad.categories.length > 0) {
       return this.ad.categories;
     }
     return [];
   }
 
-  /** 
+  /**
    * @typedef {object} BlockedAdCategory
    * @property {string} authority
    * @property {string} value
    * @return {BlockedAdCategory[]}
    */
   get adBlockedAdCategories() {
-    // <BlockedAdCategories authority=”iabtechlab.com”>232</BlockedAdCategories> 
+    // <BlockedAdCategories authority=”iabtechlab.com”>232</BlockedAdCategories>
     if (this.ad && this.ad.blockedAdCategories && this.ad.blockedAdCategories.length > 0) {
       return this.ad.blockedAdCategories;
     }
     return [];
   }
 
-  /** 
-   * @type {() => number} 
+  /**
+   * @type {() => number}
    */
   get adDuration() {
     if (this.__adOnStage && this.creative && this.creative.isLinear) {
@@ -1066,8 +1066,8 @@ export default class RmpVast {
     return -1;
   }
 
-  /** 
-   * @type {() => number} 
+  /**
+   * @type {() => number}
    */
   get adCurrentTime() {
     if (this.__adOnStage && this.creative && this.creative.isLinear) {
@@ -1085,8 +1085,8 @@ export default class RmpVast {
     return -1;
   }
 
-  /** 
-   * @type {() => number} 
+  /**
+   * @type {() => number}
    */
   get adRemainingTime() {
     if (this.__adOnStage && this.creative && this.creative.isLinear) {
@@ -1108,15 +1108,15 @@ export default class RmpVast {
     return -1;
   }
 
-  /** 
-   * @type {() => boolean} 
+  /**
+   * @type {() => boolean}
    */
   get adOnStage() {
     return this.__adOnStage;
   }
 
-  /** 
-   * @type {() => number} 
+  /**
+   * @type {() => number}
    */
   get adMediaWidth() {
     if (this.__adOnStage) {
@@ -1129,8 +1129,8 @@ export default class RmpVast {
     return -1;
   }
 
-  /** 
-   * @type {() => number} 
+  /**
+   * @type {() => number}
    */
   get adMediaHeight() {
     if (this.__adOnStage) {
@@ -1143,8 +1143,8 @@ export default class RmpVast {
     return -1;
   }
 
-  /** 
-   * @type {() => string} 
+  /**
+   * @type {() => string}
    */
   get clickThroughUrl() {
     if (this.creative && this.creative.clickThroughUrl) {
@@ -1153,8 +1153,8 @@ export default class RmpVast {
     return '';
   }
 
-  /** 
-   * @type {() => number} 
+  /**
+   * @type {() => number}
    */
   get skipTimeOffset() {
     if (this.creative && this.creative.skipoffset) {
@@ -1163,8 +1163,8 @@ export default class RmpVast {
     return -1;
   }
 
-  /** 
-   * @type {() => boolean} 
+  /**
+   * @type {() => boolean}
    */
   get isSkippableAd() {
     if (this.creative && this.creative.isSkippableAd) {
@@ -1173,14 +1173,14 @@ export default class RmpVast {
     return false;
   }
 
-  /** 
-   * @type {() => boolean} 
+  /**
+   * @type {() => boolean}
    */
   get contentPlayerCompleted() {
     return this.contentCompleted;
   }
 
-  /** 
+  /**
    * @param {boolean} value
    * @return {void}
    */
@@ -1190,29 +1190,29 @@ export default class RmpVast {
     }
   }
 
-  /** 
-   * @type {() => string} 
+  /**
+   * @type {() => string}
    */
   get adErrorMessage() {
     return this.__adErrorMessage;
   }
 
-  /** 
-   * @type {() => number} 
+  /**
+   * @type {() => number}
    */
   get adVastErrorCode() {
     return this.__vastErrorCode;
   }
 
-  /** 
-   * @type {() => string} 
+  /**
+   * @type {() => string}
    */
   get adErrorType() {
     return this.__adErrorType;
   }
 
-  /** 
-   * @type {() => boolean} 
+  /**
+   * @type {() => boolean}
    */
   get adSkippableState() {
     if (this.__adOnStage) {
@@ -1229,28 +1229,28 @@ export default class RmpVast {
     return false;
   }
 
-  /** 
+  /**
    * @return {HTMLMediaElement|null}
    */
   get adPlayer() {
     return this.currentAdPlayer;
   }
 
-  /** 
+  /**
    * @return {HTMLMediaElement|null}
    */
   get contentPlayer() {
     return this.currentContentPlayer;
   }
 
-  /** 
-   * @type {() => boolean} 
+  /**
+   * @type {() => boolean}
    */
   get initialized() {
     return this.rmpVastInitialized;
   }
 
-  /** 
+  /**
    * @typedef {object} AdPod
    * @property {number} adPodCurrentIndex
    * @property {number} adPodLength
@@ -1269,14 +1269,14 @@ export default class RmpVast {
     };
   }
 
-  /** 
-   * @type {() => string} 
+  /**
+   * @type {() => string}
    */
   get companionAdsRequiredAttribute() {
     return this.rmpVastCompanionCreative.requiredAttribute;
   }
 
-  /** 
+  /**
    * @param {number} inputWidth
    * @param {number} inputHeight
    * @typedef {object} Companion
@@ -1294,7 +1294,7 @@ export default class RmpVast {
     return this.rmpVastCompanionCreative.getList(inputWidth, inputHeight);
   }
 
-  /** 
+  /**
    * @param {number} index
    * @return {HTMLElement|null}
    */
@@ -1302,8 +1302,8 @@ export default class RmpVast {
     return this.rmpVastCompanionCreative.getItem(index);
   }
 
-  /** 
-   * @type {() => void} 
+  /**
+   * @type {() => void}
    */
   initialize() {
     if (!this.rmpVastInitialized) {
@@ -1314,8 +1314,8 @@ export default class RmpVast {
   }
 
   // VPAID methods
-  /** 
-   * @type {(width: number, height: number, viewMode: string) => void} 
+  /**
+   * @type {(width: number, height: number, viewMode: string) => void}
    */
   resizeAd(width, height, viewMode) {
     if (this.rmpVastVpaidPlayer) {
@@ -1323,8 +1323,8 @@ export default class RmpVast {
     }
   }
 
-  /** 
-   * @type {() => void} 
+  /**
+   * @type {() => void}
    */
   expandAd() {
     if (this.rmpVastVpaidPlayer) {
@@ -1332,8 +1332,8 @@ export default class RmpVast {
     }
   }
 
-  /** 
-   * @type {() => void} 
+  /**
+   * @type {() => void}
    */
   collapseAd() {
     if (this.rmpVastVpaidPlayer) {
@@ -1341,8 +1341,8 @@ export default class RmpVast {
     }
   }
 
-  /** 
-   * @type {() => boolean} 
+  /**
+   * @type {() => boolean}
    */
   get adExpanded() {
     if (this.rmpVastVpaidPlayer) {
@@ -1351,8 +1351,8 @@ export default class RmpVast {
     return false;
   }
 
-  /** 
-   * @type {() => string} 
+  /**
+   * @type {() => string}
    */
   get vpaidCompanionAds() {
     if (this.rmpVastVpaidPlayer) {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -586,6 +586,7 @@ export default class RmpVast {
       const options = {
         timeout: this.params.ajaxTimeout,
         withCredentials: this.params.ajaxWithCredentials,
+        fetchOptions: this.params.fetchOptions,
         wrapperLimit: this.params.maxNumRedirects,
         resolveAll: false,
         allowMultipleAds: true

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -33,13 +33,13 @@ export default class RmpVast {
    * @typedef {object} Labels
    * @property {string} [skipMessage]
    * @property {string} [closeAd]
-   * @property {string} [textForInteractionUIOnMobile]
+   * @property {string} [textForInteractionUIOnMobile] 
    * @typedef {object} RmpVastParams
    * @property {number} [ajaxTimeout] - timeout in ms for an AJAX request to load a VAST tag from the ad server.
    *  Default 8000.
-   * @property {number} [creativeLoadTimeout] - timeout in ms to load linear media creative from the server.
+   * @property {number} [creativeLoadTimeout] - timeout in ms to load linear media creative from the server. 
    *  Default 10000.
-   * @property {boolean} [ajaxWithCredentials] - AJAX request to load VAST tag from ad server should or should not be
+   * @property {boolean} [ajaxWithCredentials] - AJAX request to load VAST tag from ad server should or should not be 
    *  made with credentials. Default: false.
    * @property {number} [maxNumRedirects] - the number of VAST wrappers the player should follow before triggering an
    *  error. Default: 4. Capped at 30 to avoid infinite wrapper loops.
@@ -47,23 +47,23 @@ export default class RmpVast {
    * @property {boolean} [showControlsForAdPlayer] - Shows Ad player HTML5 default video controls. Default: false.
    * @property {boolean} [vastXmlInput] - Instead of a VAST URI, we provide directly to rmp-vast VAST XML. Default: false.
    * @property {boolean} [enableVpaid] - Enables VPAID support or not. Default: true.
-   * @property {VpaidSettings} [vpaidSettings] - Information required to display VPAID creatives - note that it is up
+   * @property {VpaidSettings} [vpaidSettings] - Information required to display VPAID creatives - note that it is up 
    *  to the parent application of rmp-vast to provide those informations
    * @property {boolean} [useHlsJS] - Enables hls.js usage to display creatives delivered in HLS format on all devices. Include hls.js library (./externals/hls/hls.min.js) in your page before usage. Default: true.
    * @property {boolean} [debugHlsJS] - Enables debug log when hls.js is used to stream creatives. Default: false.
    * @property {boolean} [debugRawConsoleLogs] - Enables raw debug console log for Flutter apps and legacy platforms. Default: false.
   * @property {boolean} [omidSupport] - Enables OMID (OM Web SDK) support in rmp-vast. Default: false.
-   * @property {string[]} [omidAllowedVendors] - List of allowed vendors for ad verification. Vendors not listed will
+   * @property {string[]} [omidAllowedVendors] - List of allowed vendors for ad verification. Vendors not listed will 
    *  be rejected. Default: [].
-   * @property {boolean} [omidAutoplay] - The content player will autoplay or not. The possibility of autoplay is not
-   *  determined by rmp-vast, this information needs to be passed to rmp-vast (see this
+   * @property {boolean} [omidAutoplay] - The content player will autoplay or not. The possibility of autoplay is not 
+   *  determined by rmp-vast, this information needs to be passed to rmp-vast (see this 
    *  script for example). Default: false (means a click to play is required).
    * @property {string} [partnerName] - partnerName for OMID. Default: 'rmp-vast'.
    * @property {string} [partnerVersion] - partnerVersion for OMID. Default: current rmp-vast version 'x.x.x'.
-   * @property {Labels} [labels] - Information required to properly display VPAID creatives - note that it is up to the
+   * @property {Labels} [labels] - Information required to properly display VPAID creatives - note that it is up to the 
    *  parent application of rmp-vast to provide those informations
-   * @property {object} [macros] -
-   * @param {RmpVastParams} [params] - An object representing various parameters that can be passed to a rmp-vast
+   * @property {object} [macros] - 
+   * @param {RmpVastParams} [params] - An object representing various parameters that can be passed to a rmp-vast 
    *  instance and that will affect the player inner-workings. Optional parameter.
    */
   constructor(idOrElement, params) {
@@ -96,6 +96,7 @@ export default class RmpVast {
     }
 
     Logger.print(this.debugRawConsoleLogs, `Filtered params follow`, this.params);
+
     Logger.print(this.debugRawConsoleLogs, `Creating new RmpVast instance`);
 
     this.rmpVastContentPlayer = new ContentPlayer(this);
@@ -104,7 +105,7 @@ export default class RmpVast {
     this.environmentData = Environment;
 
     Logger.printVideoEvents(this.debugRawConsoleLogs, this.currentContentPlayer, 'content');
-    // reset loadAds variables - this is reset at addestroyed
+    // reset loadAds variables - this is reset at addestroyed 
     // so that next loadAds is cleared
     this.resetVariablesForNewLoadAds();
     // handle fullscreen events
@@ -171,9 +172,9 @@ export default class RmpVast {
   }
 
 
-  /**
+  /** 
    * Dispatch an event to the custom event system
-   * @type {(eventName: string, data: object) => void}
+   * @type {(eventName: string, data: object) => void} 
    */
   dispatch(eventName, data) {
     const event = this.events[eventName];
@@ -188,7 +189,7 @@ export default class RmpVast {
     }
   }
 
-  /**
+  /** 
    * @private
    */
   #on(eventName, callback) {
@@ -203,9 +204,9 @@ export default class RmpVast {
     event.registerCallback(callback);
   }
 
-  /**
+  /** 
    * Listen to an event from the custom event system
-   * @type {(eventName: string, callback: function) => void}
+   * @type {(eventName: string, callback: function) => void} 
    */
   on(eventName, callback) {
     if (typeof eventName !== 'string' || eventName === '' || typeof callback !== 'function') {
@@ -217,7 +218,7 @@ export default class RmpVast {
     });
   }
 
-  /**
+  /** 
    * @private
    */
   #one(eventName, callback) {
@@ -228,9 +229,9 @@ export default class RmpVast {
     this.on(eventName, newCallback);
   }
 
-  /**
+  /** 
    * Listen once to an event from the custom event system
-   * @type {(eventName: string, callback: function) => void}
+   * @type {(eventName: string, callback: function) => void} 
    */
   one(eventName, callback) {
     if (typeof eventName !== 'string' || eventName === '' || typeof callback !== 'function') {
@@ -242,7 +243,7 @@ export default class RmpVast {
     });
   }
 
-  /**
+  /** 
    * @private
    */
   #off(eventName, callback) {
@@ -259,9 +260,9 @@ export default class RmpVast {
     }
   }
 
-  /**
+  /** 
    * Unregister an event from the custom event system
-   * @type {(eventName: string, callback: function) => void}
+   * @type {(eventName: string, callback: function) => void} 
    */
   off(eventName, callback) {
     if (typeof eventName !== 'string' || eventName === '' || typeof callback !== 'function') {
@@ -273,7 +274,7 @@ export default class RmpVast {
     });
   }
 
-  /**
+  /** 
    * @private
    */
   #addTrackingEvents(trackingEvents) {
@@ -288,7 +289,7 @@ export default class RmpVast {
     });
   }
 
-  /**
+  /** 
    * @private
    */
   #handleIntersect(entries) {
@@ -301,7 +302,7 @@ export default class RmpVast {
     });
   }
 
-  /**
+  /** 
    * @private
    */
   #attachViewableObserver() {
@@ -319,7 +320,7 @@ export default class RmpVast {
     }
   }
 
-  /**
+  /** 
    * @private
    */
   #initViewableImpression() {
@@ -356,7 +357,7 @@ export default class RmpVast {
     this.on('adstarted', this.attachViewableObserverFn);
   }
 
-  /**
+  /** 
    * @private
    */
   async #loopAds(ads) {
@@ -541,7 +542,7 @@ export default class RmpVast {
     }
   }
 
-  /**
+  /** 
    * @private
    */
   #handleParsedVast(response) {
@@ -556,7 +557,7 @@ export default class RmpVast {
         });
       });
     }
-    // VAST/Ad
+    // VAST/Ad 
     if (response.ads.length === 0) {
       this.rmpVastUtils.processVastErrors(303, true);
       return;
@@ -565,7 +566,7 @@ export default class RmpVast {
     }
   }
 
-  /**
+  /** 
    * @private
    */
   #getVastTag(vastData) {
@@ -585,7 +586,6 @@ export default class RmpVast {
       const options = {
         timeout: this.params.ajaxTimeout,
         withCredentials: this.params.ajaxWithCredentials,
-        fetchOptions: this.params.fetchOptions,
         wrapperLimit: this.params.maxNumRedirects,
         resolveAll: false,
         allowMultipleAds: true
@@ -625,12 +625,12 @@ export default class RmpVast {
     }
   }
 
-  /**
+  /** 
    * @param {string} vastData - the URI to the VAST resource to be loaded - or raw VAST XML if params.vastXmlInput is true
    * @param {object} [regulationsInfo] - data for regulations as
    * @param {string} [regulationsInfo.regulations] - coppa|gdpr for REGULATIONS macro
    * @param {string} [regulationsInfo.limitAdTracking] - 0|1 for LIMITADTRACKING macro
-   * @param {string} [regulationsInfo.gdprConsent] - Base64-encoded Cookie Value of IAB GDPR consent info for
+   * @param {string} [regulationsInfo.gdprConsent] - Base64-encoded Cookie Value of IAB GDPR consent info for 
    *  GDPRCONSENT macro
    * @param {boolean} [requireCategory] - for enforcement of VAST 4 Ad Categories
    * @return {void}
@@ -675,8 +675,8 @@ export default class RmpVast {
     this.#getVastTag(finalVastData);
   }
 
-  /**
-   * @type {() => void}
+  /** 
+   * @type {() => void} 
    */
   play() {
     if (this.__adOnStage && this.creative && this.creative.isLinear) {
@@ -690,8 +690,8 @@ export default class RmpVast {
     }
   }
 
-  /**
-   * @type {() => void}
+  /** 
+   * @type {() => void} 
    */
   pause() {
     if (this.__adOnStage && this.creative && this.creative.isLinear) {
@@ -705,8 +705,8 @@ export default class RmpVast {
     }
   }
 
-  /**
-   * @type {() => void}
+  /** 
+   * @type {() => void} 
    */
   stopAds() {
     if (this.__adOnStage) {
@@ -721,10 +721,10 @@ export default class RmpVast {
     }
   }
 
-  /**
+  /** 
    * The difference between stopAds and destroy is that after calling destroy you may not call loadAds again
-   * You will need to create a new RmpVast instance.
-   * @type {() => void}
+   * You will need to create a new RmpVast instance. 
+   * @type {() => void} 
    */
   destroy() {
     this.rmpVastUtils.destroyFullscreen();
@@ -734,8 +734,8 @@ export default class RmpVast {
     this.#initInstanceVariables();
   }
 
-  /**
-   * @type {() => void}
+  /** 
+   * @type {() => void} 
    */
   skipAd() {
     if (this.__adOnStage && this.adSkippableState) {
@@ -750,7 +750,7 @@ export default class RmpVast {
     }
   }
 
-  /**
+  /** 
  * @typedef {object} Environment
  * @property {number} devicePixelRatio
  * @property {number} maxTouchPoints
@@ -767,8 +767,8 @@ export default class RmpVast {
     return this.environmentData;
   }
 
-  /**
-   * @type {() => boolean}
+  /** 
+   * @type {() => boolean} 
    */
   get adPaused() {
     if (this.__adOnStage && this.creative && this.creative.isLinear) {
@@ -781,8 +781,8 @@ export default class RmpVast {
     return false;
   }
 
-  /**
-   * @type {(level: number) => void}
+  /** 
+   * @type {(level: number) => void} 
    */
   set volume(level) {
     if (!FW.isNumber(level)) {
@@ -807,8 +807,8 @@ export default class RmpVast {
     this.rmpVastContentPlayer.volume = validatedLevel;
   }
 
-  /**
-   * @type {() => number}
+  /** 
+   * @type {() => number} 
    */
   get volume() {
     if (this.__adOnStage && this.creative && this.creative.isLinear) {
@@ -821,8 +821,8 @@ export default class RmpVast {
     return this.rmpVastContentPlayer.volume;
   }
 
-  /**
-   * @type {(muted: boolean) => void}
+  /** 
+   * @type {(muted: boolean) => void} 
    */
   set muted(muted) {
     if (typeof muted !== 'boolean') {
@@ -842,8 +842,8 @@ export default class RmpVast {
     this.rmpVastContentPlayer.muted = muted;
   }
 
-  /**
-   * @type {() => boolean}
+  /** 
+   * @type {() => boolean} 
    */
   get muted() {
     if (this.__adOnStage && this.creative && this.creative.isLinear) {
@@ -859,15 +859,15 @@ export default class RmpVast {
     return this.rmpVastContentPlayer.muted;
   }
 
-  /**
-   * @type {() => string}
+  /** 
+   * @type {() => string} 
    */
   get adTagUrl() {
     return this.__adTagUrl;
   }
 
-  /**
-   * @type {() => string}
+  /** 
+   * @type {() => string} 
    */
   get adMediaUrl() {
     if (this.__adOnStage) {
@@ -882,8 +882,8 @@ export default class RmpVast {
     return '';
   }
 
-  /**
-   * @type {() => boolean}
+  /** 
+   * @type {() => boolean} 
    */
   get adLinear() {
     if (this.creative && this.creative.isLinear) {
@@ -892,7 +892,7 @@ export default class RmpVast {
     return false;
   }
 
-  /**
+  /** 
    * @typedef {object} AdSystem
    * @property {string} value
    * @property {string} version
@@ -914,7 +914,7 @@ export default class RmpVast {
     };
   }
 
-  /**
+  /** 
    * @typedef {object} universalAdId
    * @property {string} idRegistry
    * @property {string} value
@@ -929,8 +929,8 @@ export default class RmpVast {
     return [];
   }
 
-  /**
-   * @type {() => string}
+  /** 
+   * @type {() => string} 
    */
   get adContentType() {
     if (this.creative && this.creative.type) {
@@ -939,8 +939,8 @@ export default class RmpVast {
     return '';
   }
 
-  /**
-   * @type {() => string}
+  /** 
+   * @type {() => string} 
    */
   get adTitle() {
     if (this.ad && this.ad.title) {
@@ -949,8 +949,8 @@ export default class RmpVast {
     return '';
   }
 
-  /**
-   * @type {() => string}
+  /** 
+   * @type {() => string} 
    */
   get adDescription() {
     if (this.ad && this.ad.description) {
@@ -959,7 +959,7 @@ export default class RmpVast {
     return '';
   }
 
-  /**
+  /** 
    * @typedef {object} Advertiser
    * @property {string} id
    * @property {string} value
@@ -977,7 +977,7 @@ export default class RmpVast {
     };
   }
 
-  /**
+  /** 
    * @typedef {object} Pricing
    * @property {string} value
    * @property {string} model
@@ -997,8 +997,8 @@ export default class RmpVast {
     };
   }
 
-  /**
-   * @type {() => string}
+  /** 
+   * @type {() => string} 
    */
   get adSurvey() {
     if (this.ad && this.ad.survey) {
@@ -1010,8 +1010,8 @@ export default class RmpVast {
     };
   }
 
-  /**
-   * @type {() => string}
+  /** 
+   * @type {() => string} 
    */
   get adAdServingId() {
     if (this.ad && this.ad.adServingId) {
@@ -1020,36 +1020,36 @@ export default class RmpVast {
     return '';
   }
 
-  /**
+  /** 
    * @typedef {object} Category
    * @property {string} authority
    * @property {string} value
    * @return {Category[]}
    */
   get adCategories() {
-    // <Category authority=”iabtechlab.com”>232</Category>
+    // <Category authority=”iabtechlab.com”>232</Category> 
     if (this.ad && this.ad.categories && this.ad.categories.length > 0) {
       return this.ad.categories;
     }
     return [];
   }
 
-  /**
+  /** 
    * @typedef {object} BlockedAdCategory
    * @property {string} authority
    * @property {string} value
    * @return {BlockedAdCategory[]}
    */
   get adBlockedAdCategories() {
-    // <BlockedAdCategories authority=”iabtechlab.com”>232</BlockedAdCategories>
+    // <BlockedAdCategories authority=”iabtechlab.com”>232</BlockedAdCategories> 
     if (this.ad && this.ad.blockedAdCategories && this.ad.blockedAdCategories.length > 0) {
       return this.ad.blockedAdCategories;
     }
     return [];
   }
 
-  /**
-   * @type {() => number}
+  /** 
+   * @type {() => number} 
    */
   get adDuration() {
     if (this.__adOnStage && this.creative && this.creative.isLinear) {
@@ -1066,8 +1066,8 @@ export default class RmpVast {
     return -1;
   }
 
-  /**
-   * @type {() => number}
+  /** 
+   * @type {() => number} 
    */
   get adCurrentTime() {
     if (this.__adOnStage && this.creative && this.creative.isLinear) {
@@ -1085,8 +1085,8 @@ export default class RmpVast {
     return -1;
   }
 
-  /**
-   * @type {() => number}
+  /** 
+   * @type {() => number} 
    */
   get adRemainingTime() {
     if (this.__adOnStage && this.creative && this.creative.isLinear) {
@@ -1108,15 +1108,15 @@ export default class RmpVast {
     return -1;
   }
 
-  /**
-   * @type {() => boolean}
+  /** 
+   * @type {() => boolean} 
    */
   get adOnStage() {
     return this.__adOnStage;
   }
 
-  /**
-   * @type {() => number}
+  /** 
+   * @type {() => number} 
    */
   get adMediaWidth() {
     if (this.__adOnStage) {
@@ -1129,8 +1129,8 @@ export default class RmpVast {
     return -1;
   }
 
-  /**
-   * @type {() => number}
+  /** 
+   * @type {() => number} 
    */
   get adMediaHeight() {
     if (this.__adOnStage) {
@@ -1143,8 +1143,8 @@ export default class RmpVast {
     return -1;
   }
 
-  /**
-   * @type {() => string}
+  /** 
+   * @type {() => string} 
    */
   get clickThroughUrl() {
     if (this.creative && this.creative.clickThroughUrl) {
@@ -1153,8 +1153,8 @@ export default class RmpVast {
     return '';
   }
 
-  /**
-   * @type {() => number}
+  /** 
+   * @type {() => number} 
    */
   get skipTimeOffset() {
     if (this.creative && this.creative.skipoffset) {
@@ -1163,8 +1163,8 @@ export default class RmpVast {
     return -1;
   }
 
-  /**
-   * @type {() => boolean}
+  /** 
+   * @type {() => boolean} 
    */
   get isSkippableAd() {
     if (this.creative && this.creative.isSkippableAd) {
@@ -1173,14 +1173,14 @@ export default class RmpVast {
     return false;
   }
 
-  /**
-   * @type {() => boolean}
+  /** 
+   * @type {() => boolean} 
    */
   get contentPlayerCompleted() {
     return this.contentCompleted;
   }
 
-  /**
+  /** 
    * @param {boolean} value
    * @return {void}
    */
@@ -1190,29 +1190,29 @@ export default class RmpVast {
     }
   }
 
-  /**
-   * @type {() => string}
+  /** 
+   * @type {() => string} 
    */
   get adErrorMessage() {
     return this.__adErrorMessage;
   }
 
-  /**
-   * @type {() => number}
+  /** 
+   * @type {() => number} 
    */
   get adVastErrorCode() {
     return this.__vastErrorCode;
   }
 
-  /**
-   * @type {() => string}
+  /** 
+   * @type {() => string} 
    */
   get adErrorType() {
     return this.__adErrorType;
   }
 
-  /**
-   * @type {() => boolean}
+  /** 
+   * @type {() => boolean} 
    */
   get adSkippableState() {
     if (this.__adOnStage) {
@@ -1229,28 +1229,28 @@ export default class RmpVast {
     return false;
   }
 
-  /**
+  /** 
    * @return {HTMLMediaElement|null}
    */
   get adPlayer() {
     return this.currentAdPlayer;
   }
 
-  /**
+  /** 
    * @return {HTMLMediaElement|null}
    */
   get contentPlayer() {
     return this.currentContentPlayer;
   }
 
-  /**
-   * @type {() => boolean}
+  /** 
+   * @type {() => boolean} 
    */
   get initialized() {
     return this.rmpVastInitialized;
   }
 
-  /**
+  /** 
    * @typedef {object} AdPod
    * @property {number} adPodCurrentIndex
    * @property {number} adPodLength
@@ -1269,14 +1269,14 @@ export default class RmpVast {
     };
   }
 
-  /**
-   * @type {() => string}
+  /** 
+   * @type {() => string} 
    */
   get companionAdsRequiredAttribute() {
     return this.rmpVastCompanionCreative.requiredAttribute;
   }
 
-  /**
+  /** 
    * @param {number} inputWidth
    * @param {number} inputHeight
    * @typedef {object} Companion
@@ -1294,7 +1294,7 @@ export default class RmpVast {
     return this.rmpVastCompanionCreative.getList(inputWidth, inputHeight);
   }
 
-  /**
+  /** 
    * @param {number} index
    * @return {HTMLElement|null}
    */
@@ -1302,8 +1302,8 @@ export default class RmpVast {
     return this.rmpVastCompanionCreative.getItem(index);
   }
 
-  /**
-   * @type {() => void}
+  /** 
+   * @type {() => void} 
    */
   initialize() {
     if (!this.rmpVastInitialized) {
@@ -1314,8 +1314,8 @@ export default class RmpVast {
   }
 
   // VPAID methods
-  /**
-   * @type {(width: number, height: number, viewMode: string) => void}
+  /** 
+   * @type {(width: number, height: number, viewMode: string) => void} 
    */
   resizeAd(width, height, viewMode) {
     if (this.rmpVastVpaidPlayer) {
@@ -1323,8 +1323,8 @@ export default class RmpVast {
     }
   }
 
-  /**
-   * @type {() => void}
+  /** 
+   * @type {() => void} 
    */
   expandAd() {
     if (this.rmpVastVpaidPlayer) {
@@ -1332,8 +1332,8 @@ export default class RmpVast {
     }
   }
 
-  /**
-   * @type {() => void}
+  /** 
+   * @type {() => void} 
    */
   collapseAd() {
     if (this.rmpVastVpaidPlayer) {
@@ -1341,8 +1341,8 @@ export default class RmpVast {
     }
   }
 
-  /**
-   * @type {() => boolean}
+  /** 
+   * @type {() => boolean} 
    */
   get adExpanded() {
     if (this.rmpVastVpaidPlayer) {
@@ -1351,8 +1351,8 @@ export default class RmpVast {
     return false;
   }
 
-  /**
-   * @type {() => string}
+  /** 
+   * @type {() => string} 
    */
   get vpaidCompanionAds() {
     if (this.rmpVastVpaidPlayer) {


### PR DESCRIPTION
Some VAST providers require their own authentication headers, e.g. 'x-api-key: .......'

This pull request just adds a fetchOptions object as a param for rmp-vast so we are able to pass through those custom headers (and possibly other options) to the VAST client, which is already expecting and handling this object by adding the options to the fetch request.

Example use:

```
const params = {
  ajaxTimeout: 5000,           //default 8000
  creativeLoadTimeout: 5000,   //default 10000
  fetchOptions: {
    'headers': {'x-api-key': '1234'}
  }
};
const rmpVast = new RmpVast('rmp', params);
```